### PR TITLE
changing scripts to just use npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
 	"scripts": {
 		"lint": "",
 		"clean": "rimraf dist",
-		"build": "pnpm clean && rollup -c",
+		"build": "npm clean && rollup -c",
 		"build:w": "rollup -w -c",
-		"pretest": "pnpm build",
-		"prepublishOnly": "pnpm build",
+		"pretest": "npm build",
+		"prepublishOnly": "npm build",
 		"prepare": "npm build"
 	},
 	"repository": {


### PR DESCRIPTION
makes it easier to use everywhere, including relying on local builds